### PR TITLE
Add contents to SETUP.md

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,12 @@
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://help.exercism.io/getting-started-with-lfe.html).
+
+For running the tests provided, you will need `make`.  Open a terminal
+window and run the following from the exercise directory:
+
+    make test
+
+And you should now be able to see the results of the test suite for
+the exercise.


### PR DESCRIPTION
To run the tests was not obvious for a beginner, and required
digging into the issues on the exercism/xlfe repo to determine
how to run the tests, as there is not a clear and explicit
path to do so in the README.md unlike other languages.

Add the recommendation for using `make` and running `make test`
to run the tests for the exercise folder the user is in.