### PR TITLE
[grade-school] Update `get-students-in-a-non-existant-grade_test`

### DIFF
--- a/exercises/grade-school/test/grade-school-tests.lfe
+++ b/exercises/grade-school/test/grade-school-tests.lfe
@@ -30,7 +30,7 @@
     (is-equal '("Bradley" "Franklin") (lists:sort students))))
 
 (deftest get-students-in-a-non-existant-grade
-  (is-equal (grade-school:new) (grade-school:get 1 '())))
+  (is-equal '() (grade-school:get 1 (grade-school:new))))
 
 (deftest sort-school
   (let* ((school (grade-school:add "Jennifer"    4 (grade-school:new)))


### PR DESCRIPTION
The old version of the test in question assumed the following:

a) you are using a list to represent your school
b) an empty classroom/roster is equal to an empty school

This change does introduce complete agnosticity about the structure of
the school itself. Also now `grade-school:get/2` is expected to always
return an ordered list of names.

This PR does follow the same spirit as exercism/xerlang#72