### PR TITLE
Update instructions for starting LFE exercises

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,77 +1,39 @@
-Setup needed (only needs to be done once):
-
-```bash
-$ cd /path/to/exercism/lfe
-$ rebar get-deps compile
-$ export ERL_LIBS=$(find deps -maxdepth 1 -mindepth 1 | tr '\n' ':')
-```
-
-If you're not using Bash, change the last command to what is needed to set an
-environment variable in your shell, e.g. for [fish][2]:
-
-```fish
-$ set -xU ERL_LIBS (find deps -maxdepth 1 -mindepth 1 | tr '\n' ':')
-```
-
-[2]: http://fishshell.com
-
 For each example, the following general steps are required.
 
-First, compile the module and its tests.
+First, change directory to the exercise you want to practice, in
+this case `bob`.
 
 ```bash
-$ cd /path/to/exercism/lfe/<exercise>
+$ cd </path/to/exercism>/lfe/bob
 ```
 
-```bash
-$ mkdir -p ebin
-$ lfec -o ebin src/<module>.lfe test/<module>-tests.lfe
-```
+Next run the tests.  The `test` make target depends on `compile`,
+so running `make test` will ensure your source is compiled,
+ and then proceed to run the tests.
 
-or
-
-```bash
-$ cd bob
-$ make compile
-```
-
-Then run the tests.
-
-```bash
-$ lfe -pa ebin -noshell -eval \
-  "(eunit:test '<module>-tests '(verbose))" \
-  -s init stop
-```
-
-or
 
 ```bash
 $ make test
 ```
 
-NB The `test` make target depends on `compile`, so to compile
-and test, `make test` is all that's required.
+Congratulations! You have failing tests!!!
+
+Now read `README.md` to find out what you need to do to get all
+your tests passing.
 
 
-Here's a specific example, using the "bob" exercise:
-
-```bash
-$ cd bob
-$ mkdir -p ebin
-$ lfec -o ebin src/bob.lfe test/bob-tests.lfe
-$ lfe -pa ebin -noshell -eval \
-  "(eunit:test 'bob-tests '(verbose))" \
-  -s init stop
-```
-
-Or, using `make`:
+Fix the first error reported by the test, and run the tests again.
 
 ```bash
 $ make test
 ```
 
-Although in the wild, LFE dependencies are conventionally project-local,
-we've set up symbolic links in each exercise to `../deps`, meaning you only
-have to call `rebar get-deps compile` once in the lfe track directory
-and the resulting `deps` will be shared across all the exercises.
+Continue by fixing the next failing test in your source code, and
+running your test until you get all the test passing.
+
+Once all your test pass, take a final look over your code in the `src`
+directory to ensure you are happy with your code and submit for review.
+
+Get feedback, revise solution, submit, try next exercise, and recurse
+until LFE enlightenment is achieved.
 


### PR DESCRIPTION
There were two different options in best to get up and running.

This change reduces the instructions to only outline how to
get up and running by using `make`.

The hope is that by giving the reader only one path to follow,
this eases the getting started flow as the reader doesn't have
to try and make guesses about what needs to be done without
having deep context of the toolchain that LFE uses, if they
are wanting to get up and running to see if LFE is something
they might want to invest more time into learning.